### PR TITLE
add jspecify null annotations to the project

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -25,6 +25,11 @@
             <version>1.0.2</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
         <!-- TEST -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/client/src/main/java/no/helseid/clientassertion/AssertionDetails.java
+++ b/client/src/main/java/no/helseid/clientassertion/AssertionDetails.java
@@ -3,6 +3,7 @@ package no.helseid.clientassertion;
 import no.helseid.configuration.Tenancy;
 import no.helseid.endpoints.token.TokenRequestDetails;
 import no.helseid.exceptions.HelseIdException;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,6 +12,7 @@ import java.util.Map;
 /**
  * Utility class for creating the assertion details
  */
+@NullMarked
 public abstract class AssertionDetails {
 
   /**

--- a/client/src/main/java/no/helseid/configuration/Client.java
+++ b/client/src/main/java/no/helseid/configuration/Client.java
@@ -1,6 +1,7 @@
 package no.helseid.configuration;
 
 import no.helseid.signing.KeyReference;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.Set;
 
@@ -10,5 +11,6 @@ import java.util.Set;
  * @param keyReference a key reference to
  * @param scope a set of scopes requested for the client
  */
+@NullMarked
 public record Client(String clientId, KeyReference keyReference, Set<String> scope) {
 }

--- a/client/src/main/java/no/helseid/dpop/DPoPProofCreator.java
+++ b/client/src/main/java/no/helseid/dpop/DPoPProofCreator.java
@@ -1,12 +1,14 @@
 package no.helseid.dpop;
 
 import no.helseid.exceptions.HelseIdException;
+import org.jspecify.annotations.NullMarked;
 
 import java.net.URI;
 
 /**
  * Interface for creation of DPoP-proofs
  */
+@NullMarked
 public interface DPoPProofCreator {
 
   /**

--- a/client/src/main/java/no/helseid/dpop/DefaultDPoPProofCreator.java
+++ b/client/src/main/java/no/helseid/dpop/DefaultDPoPProofCreator.java
@@ -12,6 +12,8 @@ import com.nimbusds.oauth2.sdk.token.DPoPAccessToken;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import no.helseid.exceptions.HelseIdException;
 import no.helseid.signing.KeyReference;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 import java.text.ParseException;
@@ -21,6 +23,7 @@ import static no.helseid.signing.Util.createJWKFromKeyReference;
 /**
  * Default implementation of a DPoPProofCreator
  */
+@NullMarked
 public class DefaultDPoPProofCreator implements DPoPProofCreator {
   private final DPoPProofFactory factory;
   private final String keyId;
@@ -78,7 +81,7 @@ public class DefaultDPoPProofCreator implements DPoPProofCreator {
    * @return string formatted DPoP-Proof
    * @throws HelseIdException if unable to create a DPoP-Proof, usually the thumbprint in the access token does not match the signing key
    */
-  private String createDPoPProof(URI htu, HttpMethod htm, String nonce, String accessToken) throws HelseIdException {
+  private String createDPoPProof(URI htu, HttpMethod htm, @Nullable String nonce,@Nullable String accessToken) throws HelseIdException {
     if (accessToken != null) {
       try {
         Base64URL accessTokenJwkThumbprint = JWKThumbprintConfirmation.parse(SignedJWT.parse(accessToken).getJWTClaimsSet()).getValue();

--- a/client/src/main/java/no/helseid/dpop/HttpMethod.java
+++ b/client/src/main/java/no/helseid/dpop/HttpMethod.java
@@ -1,8 +1,11 @@
 package no.helseid.dpop;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
  * Representation of HTTP Methods
  */
+@NullMarked
 public final class HttpMethod {
   /**
    * GET method <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.1">as described in RFC 7231</a>

--- a/client/src/main/java/no/helseid/endpoints/token/AccessTokenResponse.java
+++ b/client/src/main/java/no/helseid/endpoints/token/AccessTokenResponse.java
@@ -1,10 +1,13 @@
 package no.helseid.endpoints.token;
 
+import org.jspecify.annotations.NullMarked;
+
 import java.util.Set;
 
 /**
  * A representation of a successful response from the token-endpoint in HelseID
  */
+@NullMarked
 public final class AccessTokenResponse extends TokenResponse {
   private final String accessToken;
   private final String tokenType;

--- a/client/src/main/java/no/helseid/endpoints/token/ErrorResponse.java
+++ b/client/src/main/java/no/helseid/endpoints/token/ErrorResponse.java
@@ -1,8 +1,11 @@
 package no.helseid.endpoints.token;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
  * A representation of an error response from the token-endpoint in HelseID
  */
+@NullMarked
 public final class ErrorResponse extends TokenResponse {
   private final String error;
   private final String errorDescription;

--- a/client/src/main/java/no/helseid/endpoints/token/TokenRequestDetails.java
+++ b/client/src/main/java/no/helseid/endpoints/token/TokenRequestDetails.java
@@ -2,17 +2,20 @@ package no.helseid.endpoints.token;
 
 import no.helseid.configuration.Tenancy;
 import no.helseid.exceptions.HelseIdException;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.*;
 
 /**
  * A collection of details in a token request
  */
+@NullMarked
 public final class TokenRequestDetails {
   private final Tenancy tenancy;
-  private final String parentOrganizationNumber;
-  private final String childOrganizationNumber;
-  private final String sfmJournalId;
+  private final @Nullable String parentOrganizationNumber;
+  private final @Nullable String childOrganizationNumber;
+  private final @Nullable String sfmJournalId;
   private final Set<String> scope;
 
   /**
@@ -27,9 +30,9 @@ public final class TokenRequestDetails {
    */
   public TokenRequestDetails(
       Tenancy tenancy,
-      String parentOrganizationNumber,
-      String childOrganizationNumber,
-      String sfmJournalId,
+      @Nullable String parentOrganizationNumber,
+      @Nullable String childOrganizationNumber,
+      @Nullable String sfmJournalId,
       Set<String> scope
   ) {
     this.tenancy = tenancy;
@@ -51,7 +54,7 @@ public final class TokenRequestDetails {
    * Returning the parent organization number of the request
    * @return the parent organization number of the request
    */
-  public String parentOrganizationNumber() {
+  public @Nullable String parentOrganizationNumber() {
     return parentOrganizationNumber;
   }
 
@@ -59,7 +62,7 @@ public final class TokenRequestDetails {
    * Returning the child organization number of the request
    * @return the child organization number of the request
    */
-  public String childOrganizationNumber() {
+  public @Nullable String childOrganizationNumber() {
     return childOrganizationNumber;
   }
 
@@ -67,7 +70,7 @@ public final class TokenRequestDetails {
    * Returning the SFM journal-id of the request
    * @return the SFM journal-id of the request
    */
-  public String sfmJournalId() {
+  public @Nullable String sfmJournalId() {
     return sfmJournalId;
   }
 
@@ -85,9 +88,9 @@ public final class TokenRequestDetails {
   public static class Builder {
     private final Set<String> scopeSet = new HashSet<>();
     private Tenancy tenancy = Tenancy.SINGLE_TENANT;
-    private String parentOrganizationNumber;
-    private String childOrganizationNumber;
-    private String sfmJournalId;
+    private @Nullable String parentOrganizationNumber;
+    private @Nullable String childOrganizationNumber;
+    private @Nullable String sfmJournalId;
 
     /**
      * Create a new Builder instance for TokenRequestDetails

--- a/client/src/main/java/no/helseid/endpoints/token/TokenResponse.java
+++ b/client/src/main/java/no/helseid/endpoints/token/TokenResponse.java
@@ -1,8 +1,11 @@
 package no.helseid.endpoints.token;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
  * A generic representation of a response from the token endpoint in HelseID
  */
+@NullMarked
 public abstract class TokenResponse {
   private final String rawResponseBody;
   private final int statusCode;

--- a/client/src/main/java/no/helseid/grants/ClientCredentials.java
+++ b/client/src/main/java/no/helseid/grants/ClientCredentials.java
@@ -11,12 +11,15 @@ import no.helseid.endpoints.token.TokenResponse;
 import no.helseid.exceptions.HelseIdException;
 import no.helseid.metadata.MetadataProvider;
 import no.helseid.metadata.RemoteMetadataProvider;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 
 /**
  * Client Credentials pattern
  */
+@NullMarked
 public interface ClientCredentials {
   /**
    * Request access token from HelseID without details, the token is cached and referenced thru-out it's lifetime
@@ -31,7 +34,7 @@ public interface ClientCredentials {
    * @return the token response from HelseID, might be a AccessTokenResponse or an ErrorResponse
    * @throws HelseIdException if a request to HelseID returned in an unprocessable failure
    */
-  TokenResponse getAccessToken(TokenRequestDetails tokenRequestDetails) throws HelseIdException;
+  TokenResponse getAccessToken(@Nullable TokenRequestDetails tokenRequestDetails) throws HelseIdException;
 
   /**
    * Returning the dpop proof creator used in client credentials
@@ -44,9 +47,9 @@ public interface ClientCredentials {
    */
   class Builder {
     private final MetadataProvider metadataProvider;
-    private Client client;
-    private ExpiringCache<AccessTokenResponse> tokenCache;
-    private DPoPProofCreator dPoPProofCreator;
+    private @Nullable Client client;
+    private @Nullable ExpiringCache<AccessTokenResponse> tokenCache;
+    private @Nullable DPoPProofCreator dPoPProofCreator;
 
     /**
      * Initialize a builder class for client credentials

--- a/client/src/main/java/no/helseid/grants/DefaultClientCredentials.java
+++ b/client/src/main/java/no/helseid/grants/DefaultClientCredentials.java
@@ -15,6 +15,8 @@ import no.helseid.endpoints.token.TokenRequestDetails;
 import no.helseid.endpoints.token.TokenResponse;
 import no.helseid.exceptions.HelseIdException;
 import no.helseid.metadata.MetadataProvider;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -26,6 +28,7 @@ import java.util.Set;
 /**
  * Default implementation of Client Credentials
  */
+@NullMarked
 public final class DefaultClientCredentials implements ClientCredentials {
   private final Client client;
   private final MetadataProvider metadataProvider;
@@ -61,7 +64,7 @@ public final class DefaultClientCredentials implements ClientCredentials {
   }
 
   @Override
-  public TokenResponse getAccessToken(TokenRequestDetails tokenRequestDetails) throws HelseIdException {
+  public TokenResponse getAccessToken(@Nullable TokenRequestDetails tokenRequestDetails) throws HelseIdException {
     var metadata = metadataProvider.getMetadata();
     var scopeSet = getCurrentScope(client, tokenRequestDetails);
 
@@ -98,7 +101,7 @@ public final class DefaultClientCredentials implements ClientCredentials {
     return tokenResponse;
   }
 
-  private String createCacheKey(Client client, TokenRequestDetails tokenRequestDetails, Set<String> scopeSet) {
+  private String createCacheKey(Client client, @Nullable TokenRequestDetails tokenRequestDetails, @Nullable Set<String> scopeSet) {
     MessageDigest digest;
     try {
       digest = MessageDigest.getInstance("SHA-256");
@@ -129,7 +132,7 @@ public final class DefaultClientCredentials implements ClientCredentials {
     return new String(digest.digest(builder.toString().getBytes()));
   }
 
-  private Set<String> getCurrentScope(Client client, TokenRequestDetails tokenRequestDetails) {
+  private Set<String> getCurrentScope(Client client, @Nullable TokenRequestDetails tokenRequestDetails) {
     if (tokenRequestDetails == null || tokenRequestDetails.scope().isEmpty()) {
       return client.scope();
     }

--- a/client/src/main/java/no/helseid/signing/ECKeyReference.java
+++ b/client/src/main/java/no/helseid/signing/ECKeyReference.java
@@ -1,6 +1,7 @@
 package no.helseid.signing;
 
 import no.helseid.exceptions.HelseIdException;
+import org.jspecify.annotations.NullMarked;
 
 import java.security.*;
 import java.util.UUID;
@@ -8,6 +9,7 @@ import java.util.UUID;
 /**
  * A Key reference to a elliptic curve key pair
  */
+@NullMarked
 public final class ECKeyReference implements KeyReference {
   private static final String ALGORITHM = "EC";
   private final KeyPair keyPair;
@@ -76,13 +78,21 @@ public final class ECKeyReference implements KeyReference {
   }
 
   @Override
-  public PrivateKey getPrivateKey() {
-    return keyPair.getPrivate();
+  public  PrivateKey getPrivateKey() throws HelseIdException {
+    var privateKey = keyPair.getPrivate();
+    if (privateKey == null) {
+      throw new HelseIdException("Missing privateKey in keypair");
+    }
+    return privateKey;
   }
 
   @Override
-  public PublicKey getPublicKey() {
-    return keyPair.getPublic();
+  public PublicKey getPublicKey() throws HelseIdException {
+    var publicKey = keyPair.getPublic();
+    if (publicKey == null) {
+      throw new HelseIdException("Missing publicKey in keypair");
+    }
+    return publicKey;
   }
 
   @Override

--- a/client/src/main/java/no/helseid/signing/JWKKeyReference.java
+++ b/client/src/main/java/no/helseid/signing/JWKKeyReference.java
@@ -4,6 +4,8 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.KeyType;
 import no.helseid.exceptions.HelseIdException;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -13,6 +15,7 @@ import java.util.UUID;
 /**
  * A key reference to a JWK
  */
+@NullMarked
 public final class JWKKeyReference implements KeyReference {
   private final JWK jwk;
   private final Algorithm algorithm;
@@ -25,7 +28,7 @@ public final class JWKKeyReference implements KeyReference {
    * @param algorithm the elliptic curve algorithm
    * @param keyId     the id of the key, a random id is generated if missing
    */
-  public JWKKeyReference(JWK jwk, Algorithm algorithm, String keyId) {
+  public JWKKeyReference(JWK jwk, Algorithm algorithm, @Nullable String keyId) {
     this.jwk = jwk;
     this.algorithm = algorithm;
     this.keyId = keyId == null ? UUID.randomUUID().toString() : keyId;

--- a/client/src/main/java/no/helseid/signing/KeyReference.java
+++ b/client/src/main/java/no/helseid/signing/KeyReference.java
@@ -1,6 +1,7 @@
 package no.helseid.signing;
 
 import no.helseid.exceptions.HelseIdException;
+import org.jspecify.annotations.NullMarked;
 
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -8,6 +9,7 @@ import java.security.PublicKey;
 /**
  * A reference to a key pair pinned to an algorithm and a key id
  */
+@NullMarked
 public interface KeyReference {
   /**
    * Access the private part of the currently referenced key

--- a/client/src/main/java/no/helseid/signing/RSAKeyReference.java
+++ b/client/src/main/java/no/helseid/signing/RSAKeyReference.java
@@ -1,6 +1,7 @@
 package no.helseid.signing;
 
 import no.helseid.exceptions.HelseIdException;
+import org.jspecify.annotations.NullMarked;
 
 import java.security.*;
 import java.util.UUID;
@@ -8,6 +9,7 @@ import java.util.UUID;
 /**
  * A Key reference to an RSA key
  */
+@NullMarked
 public final class RSAKeyReference implements KeyReference {
   private static final String ALGORITHM = "RSA";
   private static final int DEFAULT_KEY_SIZE = 4096;
@@ -51,13 +53,21 @@ public final class RSAKeyReference implements KeyReference {
   }
 
   @Override
-  public PrivateKey getPrivateKey() {
-    return keyPair.getPrivate();
+  public  PrivateKey getPrivateKey() throws HelseIdException {
+    var privateKey = keyPair.getPrivate();
+    if (privateKey == null) {
+      throw new HelseIdException("Missing privateKey in keypair");
+    }
+    return privateKey;
   }
 
   @Override
-  public PublicKey getPublicKey() {
-    return keyPair.getPublic();
+  public PublicKey getPublicKey() throws HelseIdException {
+    var publicKey = keyPair.getPublic();
+    if (publicKey == null) {
+      throw new HelseIdException("Missing publicKey in keypair");
+    }
+    return publicKey;
   }
 
   @Override

--- a/client/src/main/java/no/helseid/signing/Util.java
+++ b/client/src/main/java/no/helseid/signing/Util.java
@@ -7,6 +7,7 @@ import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.*;
 import no.helseid.exceptions.HelseIdException;
+import org.jspecify.annotations.NullMarked;
 
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
@@ -18,6 +19,8 @@ import static com.nimbusds.jose.jwk.Curve.*;
 /**
  * Util class for converting key reference to nimbus
  */
+
+@NullMarked
 public interface Util {
   /**
    * Internal use only
@@ -28,7 +31,7 @@ public interface Util {
    * @throws HelseIdException if the conversion is unsuccessful
    */
   static JWSSigner createJWSSignerFromKeyReference(KeyReference keyReference) throws HelseIdException {
-    if (no.helseid.signing.Algorithm.Family.RSA.contains(keyReference.getAlgorithm())) {
+    if (Algorithm.Family.RSA.contains(keyReference.getAlgorithm())) {
       return new RSASSASigner(keyReference.getPrivateKey());
     }
 

--- a/client/src/test/java/no/helseid/signing/UtilTest.java
+++ b/client/src/test/java/no/helseid/signing/UtilTest.java
@@ -7,6 +7,7 @@ import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.KeyType;
 import com.nimbusds.jose.jwk.KeyUse;
 import no.helseid.exceptions.HelseIdException;
+import org.jspecify.annotations.NullUnmarked;
 import org.junit.jupiter.api.Test;
 
 import java.security.PrivateKey;
@@ -52,21 +53,24 @@ class UtilTest {
   void createJWKFromKeyReference_should_reject_unsupported_algorithm() throws HelseIdException {
     KeyReference invalidKeyReference = new KeyReference() {
 
+
+      @NullUnmarked
       @Override
       public PrivateKey getPrivateKey() {
         return null;
       }
 
+      @NullUnmarked
       @Override
       public PublicKey getPublicKey() {
         return null;
       }
-
+      @NullUnmarked
       @Override
       public Algorithm getAlgorithm() {
         return null;
       }
-
+      @NullUnmarked
       @Override
       public String getKeyId() {
         return "";

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>oauth2-oidc-sdk</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
         <!-- TEST -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/common/src/main/java/no/helseid/cache/ExpiringCache.java
+++ b/common/src/main/java/no/helseid/cache/ExpiringCache.java
@@ -1,11 +1,15 @@
 package no.helseid.cache;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 /**
  * Caching interface used by HelseID internals
  * May be implemended to provide distributed caching or interactions with a custom cache
  *
  * @param <T> the class of the cached values
  */
+@NullMarked
 public interface ExpiringCache<T> {
   /**
    * Get the cached value on a key, an expired value is interpreted as missing
@@ -13,7 +17,7 @@ public interface ExpiringCache<T> {
    * @param key the key a value is cached on
    * @return cached value, null if missing or expired
    */
-  T get(String key);
+  @Nullable T get(String key);
 
 
   /**

--- a/common/src/main/java/no/helseid/cache/InMemoryExpiringCache.java
+++ b/common/src/main/java/no/helseid/cache/InMemoryExpiringCache.java
@@ -1,11 +1,15 @@
 package no.helseid.cache;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * An in-memory implementation of an expiring cache
  * @param <T> the class of the cached values
  */
+@NullMarked
 public class InMemoryExpiringCache<T> implements ExpiringCache<T> {
   private final ConcurrentHashMap<String, ExpiringValue<T>> cache = new ConcurrentHashMap<>();
 
@@ -21,7 +25,7 @@ public class InMemoryExpiringCache<T> implements ExpiringCache<T> {
    * @return the cached value if present, otherwise null
    */
   @Override
-  public T get(String key) {
+  public @Nullable T get(String key) {
     var expiringValue = cache.get(key);
 
     if (expiringValue == null ||expiringValue.expireAtEpochMilliseconds < System.currentTimeMillis()) {

--- a/common/src/main/java/no/helseid/exceptions/HelseIdException.java
+++ b/common/src/main/java/no/helseid/exceptions/HelseIdException.java
@@ -1,8 +1,11 @@
 package no.helseid.exceptions;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
  * Generic Exception wrapping exceptions occuring in this library
  */
+@NullMarked
 public class HelseIdException extends Exception {
   /**
    * Create an exception with no external cause

--- a/common/src/main/java/no/helseid/metadata/MetadataProvider.java
+++ b/common/src/main/java/no/helseid/metadata/MetadataProvider.java
@@ -2,10 +2,12 @@ package no.helseid.metadata;
 
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 import no.helseid.exceptions.HelseIdException;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Interface for providing metadata about HelseID STS
  */
+@NullMarked
 public interface MetadataProvider {
   /**
    * Get a metadata object

--- a/common/src/main/java/no/helseid/metadata/RemoteMetadataProvider.java
+++ b/common/src/main/java/no/helseid/metadata/RemoteMetadataProvider.java
@@ -6,6 +6,7 @@ import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 import no.helseid.cache.ExpiringCache;
 import no.helseid.cache.InMemoryExpiringCache;
 import no.helseid.exceptions.HelseIdException;
+import org.jspecify.annotations.NullMarked;
 
 import java.io.IOException;
 import java.net.URI;
@@ -19,6 +20,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @version 2025-08-25
  */
+@NullMarked
 public class RemoteMetadataProvider implements MetadataProvider {
   private static final Map<String, RemoteMetadataProvider> instanceMap = new ConcurrentHashMap<>();
   private static final String CACHE_KEY = "metadata";
@@ -49,13 +51,14 @@ public class RemoteMetadataProvider implements MetadataProvider {
    */
   @Override
   public OIDCProviderMetadata getMetadata() throws HelseIdException {
-    if (cache.get(CACHE_KEY) == null) {
-      var metadata = fetchMetadata();
-      cache.put(CACHE_KEY, metadata, System.currentTimeMillis() + expirationTimeInMilliseconds);
-      return metadata;
-    }
+    final var metadata = cache.get(CACHE_KEY);
+      if (metadata != null) {
+          return metadata;
+      }
+      var newMetadata = fetchMetadata();
+      cache.put(CACHE_KEY, newMetadata, System.currentTimeMillis() + expirationTimeInMilliseconds);
+      return newMetadata;
 
-    return cache.get(CACHE_KEY);
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>1.0.0</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
                 <version>[5.12.2,)</version>
@@ -134,6 +140,7 @@
                     <artifactId>maven-gpg-plugin</artifactId>
                     <version>3.2.8</version>
                 </plugin>
+
             </plugins>
         </pluginManagement>
 

--- a/selfservice/src/main/java/no/helseid/selfservice/clientsecret/ClientSecretUpdater.java
+++ b/selfservice/src/main/java/no/helseid/selfservice/clientsecret/ClientSecretUpdater.java
@@ -1,10 +1,12 @@
 package no.helseid.selfservice.clientsecret;
 
 import no.helseid.exceptions.HelseIdException;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * An interface for updating client secrets in HelseID Self-Service
  */
+@NullMarked
 public interface ClientSecretUpdater {
   /**
    * Generates a new key reference and uploads it to HelseID Self-Service

--- a/selfservice/src/main/java/no/helseid/selfservice/clientsecret/DefaultClientSecretUpdater.java
+++ b/selfservice/src/main/java/no/helseid/selfservice/clientsecret/DefaultClientSecretUpdater.java
@@ -13,6 +13,7 @@ import no.helseid.selfservice.endpoints.clientsecret.ClientSecretSuccessResponse
 import no.helseid.signing.Algorithm;
 import no.helseid.signing.RSAKeyReference;
 import no.helseid.signing.Util;
+import org.jspecify.annotations.NullMarked;
 
 import java.net.URI;
 import java.util.Set;
@@ -21,6 +22,7 @@ import java.util.Set;
 /**
  * Default implementation of a ClientSecretUpdater
  */
+@NullMarked
 public class DefaultClientSecretUpdater implements ClientSecretUpdater {
   private final URI selfServiceClientSecretEndpoint;
   private final ClientCredentials clientCredentials;

--- a/selfservice/src/main/java/no/helseid/selfservice/clientsecret/UpdatedClientSecretError.java
+++ b/selfservice/src/main/java/no/helseid/selfservice/clientsecret/UpdatedClientSecretError.java
@@ -2,13 +2,16 @@ package no.helseid.selfservice.clientsecret;
 
 import no.helseid.endpoints.token.TokenResponse;
 import no.helseid.selfservice.endpoints.clientsecret.ClientSecretResponse;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The representation of a failed update of client secret
  */
+@NullMarked
 public final class UpdatedClientSecretError extends UpdatedClientSecretResult {
-  private final TokenResponse tokenResponse;
-  private final ClientSecretResponse clientSecretResponse;
+  private final @Nullable TokenResponse tokenResponse;
+  private final @Nullable ClientSecretResponse clientSecretResponse;
 
   /**
    * Creates a UpdatedClientSecretError
@@ -16,8 +19,8 @@ public final class UpdatedClientSecretError extends UpdatedClientSecretResult {
    * @param clientSecretResponse a client secret error response if it occurred
    */
   public UpdatedClientSecretError(
-      final TokenResponse tokenResponse,
-      final ClientSecretResponse clientSecretResponse
+      final @Nullable TokenResponse tokenResponse,
+      final @Nullable ClientSecretResponse clientSecretResponse
   ) {
     this.tokenResponse = tokenResponse;
     this.clientSecretResponse = clientSecretResponse;
@@ -27,7 +30,7 @@ public final class UpdatedClientSecretError extends UpdatedClientSecretResult {
    * Access the token response
    * @return the token response
    */
-  public TokenResponse tokenResponse() {
+  public @Nullable TokenResponse tokenResponse() {
     return tokenResponse;
   }
 
@@ -35,7 +38,7 @@ public final class UpdatedClientSecretError extends UpdatedClientSecretResult {
    * Access the client secret response
    * @return the client secret response
    */
-  public ClientSecretResponse clientSecretResponse() {
+  public @Nullable ClientSecretResponse clientSecretResponse() {
     return clientSecretResponse;
   }
 }

--- a/selfservice/src/main/java/no/helseid/selfservice/clientsecret/UpdatedClientSecretResult.java
+++ b/selfservice/src/main/java/no/helseid/selfservice/clientsecret/UpdatedClientSecretResult.java
@@ -1,8 +1,11 @@
 package no.helseid.selfservice.clientsecret;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
  * A generic representation of a result from a client secret update
  */
+@NullMarked
 public abstract class UpdatedClientSecretResult {
   /**
    * Create a new instance of UpdatedClientSecretResult, used by subclasses

--- a/selfservice/src/main/java/no/helseid/selfservice/clientsecret/UpdatedClientSecretSuccess.java
+++ b/selfservice/src/main/java/no/helseid/selfservice/clientsecret/UpdatedClientSecretSuccess.java
@@ -1,10 +1,13 @@
 package no.helseid.selfservice.clientsecret;
 
+import org.jspecify.annotations.NullMarked;
+
 import java.time.ZonedDateTime;
 
 /**
  * The representation of a successful update of client secret
  */
+@NullMarked
 public final class UpdatedClientSecretSuccess extends UpdatedClientSecretResult {
   private final String jsonWebKey;
   private final ZonedDateTime expiration;

--- a/selfservice/src/main/java/no/helseid/selfservice/endpoints/clientsecret/ClientSecretEndpoint.java
+++ b/selfservice/src/main/java/no/helseid/selfservice/endpoints/clientsecret/ClientSecretEndpoint.java
@@ -5,6 +5,7 @@ import com.nimbusds.jose.util.JSONObjectUtils;
 import no.helseid.dpop.DPoPProofCreator;
 import no.helseid.dpop.HttpMethod;
 import no.helseid.exceptions.HelseIdException;
+import org.jspecify.annotations.NullMarked;
 
 import java.io.IOException;
 import java.net.URI;
@@ -18,6 +19,7 @@ import java.util.Map;
 /**
  * An implementation for communicating with the client secret endpoint in HelseID Self-Service
  */
+@NullMarked
 public interface ClientSecretEndpoint {
   /**
    * Upload a public json web key to  HelseID Self-Service
@@ -35,8 +37,7 @@ public interface ClientSecretEndpoint {
       JWK jwk
   ) throws HelseIdException {
     HttpResponse<String> httpResponse;
-    try {
-      HttpClient httpclient = HttpClient.newHttpClient();
+    try (HttpClient httpclient = HttpClient.newHttpClient();) {
       HttpRequest httpRequest = HttpRequest.newBuilder(endpoint)
           .POST(HttpRequest.BodyPublishers.ofString(jwk.toPublicJWK().toJSONString()))
           .header("Authorization", "DPoP " + accessToken)

--- a/selfservice/src/main/java/no/helseid/selfservice/endpoints/clientsecret/ClientSecretErrorResponse.java
+++ b/selfservice/src/main/java/no/helseid/selfservice/endpoints/clientsecret/ClientSecretErrorResponse.java
@@ -1,8 +1,11 @@
 package no.helseid.selfservice.endpoints.clientsecret;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
  * A representation of a failed client secret update
  */
+@NullMarked
 public final class ClientSecretErrorResponse extends ClientSecretResponse  {
   private final String type;
   private final String title;

--- a/selfservice/src/main/java/no/helseid/selfservice/endpoints/clientsecret/ClientSecretResponse.java
+++ b/selfservice/src/main/java/no/helseid/selfservice/endpoints/clientsecret/ClientSecretResponse.java
@@ -1,8 +1,11 @@
 package no.helseid.selfservice.endpoints.clientsecret;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
  * A generic representation of a client secret response
  */
+@NullMarked
 public abstract class ClientSecretResponse {
   /**
    * Create a new instance of a ClientSecretResponse, used by subclasses

--- a/selfservice/src/main/java/no/helseid/selfservice/endpoints/clientsecret/ClientSecretSuccessResponse.java
+++ b/selfservice/src/main/java/no/helseid/selfservice/endpoints/clientsecret/ClientSecretSuccessResponse.java
@@ -1,10 +1,13 @@
 package no.helseid.selfservice.endpoints.clientsecret;
 
+import org.jspecify.annotations.NullMarked;
+
 import java.time.ZonedDateTime;
 
 /**
  * A representation of a successful update of a client secret
  */
+@NullMarked
 public class ClientSecretSuccessResponse extends ClientSecretResponse {
   private final ZonedDateTime expiration;
 

--- a/selfservice/src/test/java/no/helseid/clientassertion/MockClientCredentials.java
+++ b/selfservice/src/test/java/no/helseid/clientassertion/MockClientCredentials.java
@@ -4,7 +4,10 @@ import no.helseid.dpop.DPoPProofCreator;
 import no.helseid.endpoints.token.TokenRequestDetails;
 import no.helseid.endpoints.token.TokenResponse;
 import no.helseid.grants.ClientCredentials;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public record MockClientCredentials(TokenResponse tokenResponse,
                                     DPoPProofCreator dPoPProofCreator) implements ClientCredentials {
 
@@ -14,7 +17,7 @@ public record MockClientCredentials(TokenResponse tokenResponse,
   }
 
   @Override
-  public TokenResponse getAccessToken(TokenRequestDetails tokenRequestDetails) {
+  public TokenResponse getAccessToken(@Nullable TokenRequestDetails tokenRequestDetails) {
     return tokenResponse;
   }
 

--- a/selfservice/src/test/java/no/helseid/dpop/MockDPoPProofCreator.java
+++ b/selfservice/src/test/java/no/helseid/dpop/MockDPoPProofCreator.java
@@ -1,9 +1,10 @@
 package no.helseid.dpop;
 
-import no.helseid.exceptions.HelseIdException;
+import org.jspecify.annotations.NullMarked;
 
 import java.net.URI;
 
+@NullMarked
 public class MockDPoPProofCreator implements DPoPProofCreator {
   public final String value;
   public final String keyId;

--- a/selfservice/src/test/java/no/helseid/selfservice/clientsecret/ClientSecretEndpointTest.java
+++ b/selfservice/src/test/java/no/helseid/selfservice/clientsecret/ClientSecretEndpointTest.java
@@ -12,6 +12,7 @@ import no.helseid.selfservice.endpoints.clientsecret.ClientSecretSuccessResponse
 import no.helseid.signing.Algorithm;
 import no.helseid.signing.RSAKeyReference;
 import no.helseid.signing.Util;
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -26,17 +27,18 @@ class ClientSecretEndpointTest {
   private static String CLIENT_SECRET_PATH = "/v1/client-secret";
   private WireMockServer wms;
 
-  private final DPoPProofCreator dPoPProofCreator = new DPoPProofCreator() {
+
+  private final DPoPProofCreator dPoPProofCreator = new DPoPProofCreator() {@NullMarked
     @Override
     public String createDPoPProofWithNonce(URI htu, HttpMethod htm, String nonce) {
       throw new RuntimeException("Not implemented");
     }
-
+    @NullMarked
     @Override
     public String createDPoPProof(URI htu, HttpMethod htm, String accessToken) {
       return "my.dpop.proof";
     }
-
+    @NullMarked
     @Override
     public String getKeyId() {
       return "my-key-id";


### PR DESCRIPTION
adding annotations to specify nullness for the project. Usefull for teams using Kotlin, as well as Null checkers like NullAway and The Checker Framework